### PR TITLE
Cleaner Travis Config file and Added logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,17 +31,17 @@ jobs:
       script: 
         - npm run test
     - stage: bake
-      install: chmod +x ./scripts/* && ./scripts/bake_install.sh develop
-      script: 
-        - chmod +x ./scripts/*
-        - ./scripts/build_docker_image.sh sweng-devops
+      before_install: chmod +x ./scripts/*
+      install: ./scripts/bake_install.sh develop
+      script: ./scripts/build_docker_image.sh sweng-devops
     - stage: deploy to develop
-      install: chmod +x ./scripts/* && ./scripts/install.sh develop
+      before_install: chmod +x ./scripts/*
+      install: ./scripts/install.sh develop
       script: skip
       deploy:
         - provider: script
           skip_cleanup: true
-          script: chmod +x ./scripts/* && ./scripts/deploy.sh develop
+          script: ./scripts/deploy.sh develop
           on:
             all_branches: true
     - stage: test

--- a/scripts/transfer_image.sh
+++ b/scripts/transfer_image.sh
@@ -34,12 +34,14 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 # Making sure we are logged into the UK registry
-ibmcloud cr login
 ibmcloud cr region-set uk
+ibmcloud cr login
 # Pull latest image
 docker pull $cr_endpoint_dev/$cr_namespace_dev/$cr_repository_dev:latest
 # Re-tag image
 docker tag $cr_endpoint_dev/$cr_namespace_dev/$cr_repository_dev:latest $cr_endpoint/$cr_namespace/$cr_repository:latest
+log_info "Showing docker images"
+docker images
 log_info "Pushing re-tagged image to production environment."
 # Logging into the production IBM Cloud environment.
 ibmcloud login -a https://api.eu-gb.bluemix.net --apikey $DEVOPS_IBM_PROD_KEY
@@ -48,8 +50,8 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 # Making sure we are logged into the Dallas registry
-ibmcloud cr login
 ibmcloud cr region-set us-south
+ibmcloud cr login
 docker push $cr_endpoint/$cr_namespace/$cr_repository:latest
 log_info "Making sure image was pushed to production environment."
 ibmcloud cr images


### PR DESCRIPTION
- Cleaned up the Travis config file by adding the executable permissions to the `/script` folder in the `before_install:` sections of each job, allowing us to remove them from any other command. 
- Added improved logging and error catching to the `transfer_image.sh` script, and added tagging of the images using Travis env variables of the Branch name and Build number, in the same format as they are in develop. 
